### PR TITLE
Only generate index.html if necessary

### DIFF
--- a/_plugins/alias_generator.rb
+++ b/_plugins/alias_generator.rb
@@ -61,12 +61,19 @@ module Jekyll
       alias_paths.compact!
 
       alias_paths.flatten.each do |alias_path|
-        path             = File.join(@site.dest, alias_path)
-        alias_index_path = File.join(alias_path, "index.html")
+        # If alias_path has an extension, we'll write the alias file
+        # directly to that path.  Otherwise, we'll assume that the
+        # alias_path is a directory, in which case we'll generate an
+        # index.html file.
+        alias_dir = File.extname(alias_path).empty? ? alias_path : File.dirname(alias_path)
+        alias_file = File.extname(alias_path).empty? ? "index.html" : File.basename(alias_path)
 
-        FileUtils.mkdir_p(path)
+        fs_path_to_dir = File.join(@site.dest, alias_dir)
+        alias_index_path = File.join(alias_dir, alias_file)
 
-        File.open(File.join(path, "index.html"), 'w') do |file|
+        FileUtils.mkdir_p(fs_path_to_dir)
+
+        File.open(File.join(fs_path_to_dir, alias_file), 'w') do |file|
           file.write(alias_template(destination_path))
         end
 


### PR DESCRIPTION
Previously, aliases like "/foo/bar/baz.html" would generate alias files at "/foo/bar/baz.html/index.html".  Now, if an alias ends with an extension, the alias is created directly at that path; otherwise the previous directory-based behavior is used.
