### PR TITLE
Added rel="canonical" as recommended by Google

### DIFF
--- a/_plugins/alias_generator.rb
+++ b/_plugins/alias_generator.rb
@@ -88,6 +88,7 @@ module Jekyll
       <!DOCTYPE html>
       <html>
       <head>
+      <link rel="canonical" href="#{destination_path}"/>
       <meta http-equiv="content-type" content="text/html; charset=utf-8" />
       <meta http-equiv="refresh" content="0;url=#{destination_path}" />
       </head>


### PR DESCRIPTION
Hi,

Thanks for writing such a useful plugin; I'm migrating my blog from Tumblr to GitHub Pages at the moment and this has made my life a lot easier :)

I was looking around to find out if there's a way of implementing permanent (301) redirects on Pages but it seems that these aren't yet implemented. A post on StackOverflow pointed out this Google support article (http://support.google.com/webmasters/bin/answer.py?hl=en&answer=139394) recommending the use of `<link rel="canonical" />` as a partial workaround so I added this to your plugin.

This is my first ever pull request so I apologise if I've derped anything up.

Cheers
  Simon
