### PR TITLE
Changes filename parameter of AliasFiles to empty string instead of nil

### DIFF
--- a/_plugins/alias_generator.rb
+++ b/_plugins/alias_generator.rb
@@ -71,7 +71,7 @@ module Jekyll
         end
 
         (alias_index_path.split('/').size + 1).times do |sections|
-          @site.static_files << Jekyll::AliasFile.new(@site, @site.dest, alias_index_path.split('/')[0, sections].join('/'), nil)
+          @site.static_files << Jekyll::AliasFile.new(@site, @site.dest, alias_index_path.split('/')[0, sections].join('/'), '')
         end
       end
     end


### PR DESCRIPTION
This changes the filename parameter of AliasFiles created during generation to empty string ('') instead of `nil`.

Some Jekyll plugins examine the filename of each StaticFile in `site.static_files` to determine what filetype to operate on-- one example that broke for me was https://github.com/zroger/jekyll-less (specifically, https://github.com/zroger/jekyll-less/blob/master/lib/jekyll-less.rb#L57).

If the filename is `nil`, you get this error message:

```
/Users/michael/.rvm/gems/ruby-2.0.0-p195/gems/jekyll-1.0.3/lib/jekyll/static_file.rb:21:in `join': no implicit conversion of nil into String (TypeError)
```

Unless there's a good reason for it to be `nil`, changing it to empty string fixes this.
