### PR TITLE
Add a section on how to use the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Generates redirect pages for posts with aliases set in the YAML Front Matter.
 
+## How to Run
+Place `alias_generator.rb` in your `plugins` directory, and ensure
+that you can run custom plugins (set `safe:` to `false` in `_config.yml`).
+Whenever you generate your Jekyll site, redirect pages will be created 
+at the alias path in your output directory; for example,
+`_site/post/6301645915/how-i-keep-limited-pressing-running/index.html`.
+
+## How to Use
 Place the full path of the alias (place to redirect from) inside the
 destination post's YAML Front Matter. One or more aliases may be given.
 


### PR DESCRIPTION
I could not find instructions on how to use this plugin. It turned out to be really simple, but it would have been nice to see it in the README here.
