### PR TITLE
Pass filename as `name` instead of passing full path as `dir`

### DIFF
--- a/_plugins/alias_generator.rb
+++ b/_plugins/alias_generator.rb
@@ -70,9 +70,10 @@ module Jekyll
           file.write(alias_template(destination_path))
         end
 
-        (alias_index_path.split('/').size + 1).times do |sections|
+        alias_index_path.split('/').size.times do |sections|
           @site.static_files << Jekyll::AliasFile.new(@site, @site.dest, alias_index_path.split('/')[0, sections].join('/'), '')
         end
+        @site.static_files << Jekyll::AliasFile.new(@site, @site.dest, alias_dir, alias_file)
       end
     end
 

--- a/_plugins/alias_generator.rb
+++ b/_plugins/alias_generator.rb
@@ -56,13 +56,13 @@ module Jekyll
       alias_paths.compact!
 
       alias_paths.flatten.each do |alias_path|
-        alias_path = alias_path.to_s
+        alias_path = File.join('/', alias_path.to_s)
 
         alias_dir  = File.extname(alias_path).empty? ? alias_path : File.dirname(alias_path)
         alias_file = File.extname(alias_path).empty? ? "index.html" : File.basename(alias_path)
 
-        fs_path_to_dir   = File.join(@site.dest, alias_dir)
-        alias_index_path = File.join(alias_dir, alias_file)
+        fs_path_to_dir = File.join(@site.dest, alias_dir)
+        alias_sections = alias_dir.split('/')[1..-1]
 
         FileUtils.mkdir_p(fs_path_to_dir)
 
@@ -70,8 +70,8 @@ module Jekyll
           file.write(alias_template(destination_path))
         end
 
-        alias_index_path.split('/').size.times do |sections|
-          @site.static_files << Jekyll::AliasFile.new(@site, @site.dest, alias_index_path.split('/')[0, sections].join('/'), '')
+        alias_sections.size.times do |sections|
+          @site.static_files << Jekyll::AliasFile.new(@site, @site.dest, alias_sections[0, sections + 1].join('/'), '')
         end
         @site.static_files << Jekyll::AliasFile.new(@site, @site.dest, alias_dir, alias_file)
       end


### PR DESCRIPTION
`mtime` method [has added](https://github.com/jekyll/jekyll/blob/74f0f27d18571d41eb6988a2f1e72c19c22f4c73/lib/jekyll/static_file.rb#L40) to `StaticFile`. It calls `File.stat()` and it occurs error:

```
/path/to/jekyll/lib/jekyll/static_file.rb:40:in `stat': Not a directory @ rb_file_s_stat - /path/to/generated/alias/index.html/ (Errrno::ENOTDIR)
```