### PR TITLE
Remove overloaded method from the AliasFile class (causes files to be deleted by Jekyll::Cleaner)

### DIFF
--- a/_plugins/alias_generator.rb
+++ b/_plugins/alias_generator.rb
@@ -93,10 +93,6 @@ module Jekyll
   class AliasFile < StaticFile
     require 'set'
 
-    def destination(dest)
-      File.join(dest, @dir)
-    end
-
     def modified?
       return false
     end


### PR DESCRIPTION
Alias files exhibit a weird behavior in Jekyll 2.x -- they are generated, and then disappear once the build is complete (leaving just their directories behind).

This pull request removes an overloaded method in `AliasFile` that causes these files to be deleted.

---
Jekyll 2.x improved the behavior of Jekyll::Cleaner (see jekyll/jekyll#2014), by generating a list of obsolete files that should be deleted when the site is regenerated. The list of obsolete files is determined by looking at known static files, pages, posts, and other site files. 

`AliasFile` extends `Jekyll::StaticFile`, and overloads the `destination` method:

```
def destination(dest)
  File.join(dest, @dir)
end
```
...but looking at `Jekyll::StaticFile`'s original method  (https://github.com/jekyll/jekyll/blob/master/lib/jekyll/static_file.rb#L39):

```
def destination(dest)
  File.join(*[dest, destination_rel_dir, @name].compact)
end
```

...it's not clear why this method is being overloaded. The overloaded `destination` method incorrectly includes just the directory path to the alias file, not the actual file, so the cleaner ends up removing the alias file during its cleanup phase.

---

One more note: to get this plugin working with Jekyll 2.x, I needed to merge #11 as well. It'd be great to get both of these merged into master, as Jekyll is changing quickly these days, and this plugin is outdated in `master`.

