### PR TITLE
Updating plugin for Jekyll 3

### DIFF
--- a/alias_generator.rb
+++ b/alias_generator.rb
@@ -39,7 +39,7 @@ module Jekyll
     end
 
     def process_posts
-      @site.posts.each do |post|
+      @site.posts.docs.each do |post|
         generate_aliases(post.url, post.data['alias'])
       end
     end


### PR DESCRIPTION
Jekyll 3 deprecated calling `Collection#each` in favor of `Collection#docs#each`. This change removes the deprecation warning with Jekyll 3.

Fixes #21.
