### PR TITLE
absolute url redirect instead of relative

### DIFF
--- a/alias_generator.rb
+++ b/alias_generator.rb
@@ -67,7 +67,7 @@ module Jekyll
         FileUtils.mkdir_p(fs_path_to_dir)
 
         File.open(File.join(fs_path_to_dir, alias_file), 'w') do |file|
-          file.write(alias_template(@site.config['url'] + destination_path))
+          file.write(alias_template(@site.config['url'] + @site.config['baseurl'] + destination_path))
         end
 
         alias_sections.size.times do |sections|

--- a/alias_generator.rb
+++ b/alias_generator.rb
@@ -67,7 +67,7 @@ module Jekyll
         FileUtils.mkdir_p(fs_path_to_dir)
 
         File.open(File.join(fs_path_to_dir, alias_file), 'w') do |file|
-          file.write(alias_template(destination_path))
+          file.write(alias_template(@site.config['url'] + destination_path))
         end
 
         alias_sections.size.times do |sections|


### PR DESCRIPTION
it is better to have an absolute URL for redirection instead of relative url
prefixed @site.config['url'] with post/page url

https://en.wikipedia.org/wiki/URL_redirection#Refresh_Meta_tag_and_HTTP_refresh_header
https://moz.com/community/q/301-redirect-relative-or-absolute-path#reply_195375
