### PR TITLE
Avoid posts.each deprecation warning

### DIFF
--- a/alias_generator.rb
+++ b/alias_generator.rb
@@ -39,7 +39,7 @@ module Jekyll
     end
 
     def process_posts
-      @site.posts.each do |post|
+      @site.posts.docs.each do |post|
         generate_aliases(post.url, post.data['alias'])
       end
     end


### PR DESCRIPTION
Without this patch, getting following deprecation warning in Jekyll 3.6:

```
      Deprecation: posts.each should be changed to posts.docs.each.
                    Called by ["/usr/local/lib/ruby/gems/2.4.0/gems/jekyll-3.6.0/lib/jekyll/collection.rb:39:in `method_missing'"]
```